### PR TITLE
Remove special-casing 2023.12.0

### DIFF
--- a/get
+++ b/get
@@ -88,12 +88,6 @@ function run() {
         targetYear=$(echo "${targetVersion}" | cut -d "." -f 1)
         currentYear=$(echo "${currentVersion}" | cut -d "." -f 1)
 
-        if [ "${currentVersion}" == "2023.12.0" ]; then
-            rm -R "$haPath/custom_components/hacs"
-            rm -f "$haPath/custom_components/hacs.zip"
-            error "HACS will not work on version 2023.12.0 of Home Assistant, upgrade to 2023.12.1 (or newer) before re-running this script."
-        fi
-
         if [ "${currentYear}" -lt "${targetYear}" ]; then
             rm -R "$haPath/custom_components/hacs"
             rm -f "$haPath/custom_components/hacs.zip"


### PR DESCRIPTION
HACS requires at least 2024.4.1 anyway.
This test is therefore redundant.